### PR TITLE
Fix classification metrics length mismatch handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "morphnet"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ndarray = { version = "0.15", features = ["serde"] }
+nalgebra = { version = "0.32", features = ["serde-serialize"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+bincode = "1.3"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod morphnet;

--- a/src/morphnet/classification.rs
+++ b/src/morphnet/classification.rs
@@ -1,0 +1,168 @@
+//! Classification utilities and metrics
+
+use super::*;
+
+/// Classification metrics
+#[derive(Debug, Clone)]
+pub struct ClassificationMetrics {
+    pub accuracy: f32,
+    pub precision: f32,
+    pub recall: f32,
+    pub f1_score: f32,
+    pub confusion_matrix: Array2<usize>,
+}
+
+impl ClassificationMetrics {
+    /// Calculate metrics from predictions and ground truth
+    pub fn calculate(
+        predictions: &[usize],
+        ground_truth: &[usize],
+        num_classes: usize,
+    ) -> Self {
+        let mut confusion_matrix = Array2::zeros((num_classes, num_classes));
+
+        for (&pred, &gt) in predictions.iter().zip(ground_truth.iter()) {
+            if pred < num_classes && gt < num_classes {
+                confusion_matrix[[gt, pred]] += 1;
+            }
+        }
+
+        let matched_len = predictions.len().min(ground_truth.len());
+
+        if matched_len == 0 {
+            return Self {
+                accuracy: 0.0,
+                precision: 0.0,
+                recall: 0.0,
+                f1_score: 0.0,
+                confusion_matrix,
+            };
+        }
+
+        let correct = predictions
+            .iter()
+            .zip(ground_truth.iter())
+            .filter(|(&pred, &gt)| pred == gt)
+            .count();
+        let accuracy = correct as f32 / matched_len as f32;
+
+        let mut total_precision = 0.0;
+        let mut total_recall = 0.0;
+        let mut valid_classes = 0;
+
+        for class in 0..num_classes {
+            let tp = confusion_matrix[[class, class]] as f32;
+            let fp: f32 = (0..num_classes)
+                .filter(|&i| i != class)
+                .map(|i| confusion_matrix[[i, class]] as f32)
+                .sum();
+            let fn_: f32 = (0..num_classes)
+                .filter(|&i| i != class)
+                .map(|i| confusion_matrix[[class, i]] as f32)
+                .sum();
+
+            if tp + fp > 0.0 {
+                total_precision += tp / (tp + fp);
+                valid_classes += 1;
+            }
+            if tp + fn_ > 0.0 {
+                total_recall += tp / (tp + fn_);
+            }
+        }
+
+        let precision = if valid_classes > 0 {
+            total_precision / valid_classes as f32
+        } else {
+            0.0
+        };
+        let recall = if valid_classes > 0 {
+            total_recall / valid_classes as f32
+        } else {
+            0.0
+        };
+        let f1_score = if precision + recall > 0.0 {
+            2.0 * precision * recall / (precision + recall)
+        } else {
+            0.0
+        };
+
+        Self {
+            accuracy,
+            precision,
+            recall,
+            f1_score,
+            confusion_matrix,
+        }
+    }
+}
+
+/// Species classifier utility
+pub struct SpeciesClassifier {
+    species_map: HashMap<String, usize>,
+    reverse_map: HashMap<usize, String>,
+}
+
+impl SpeciesClassifier {
+    pub fn new(species_list: Vec<String>) -> Self {
+        let mut species_map = HashMap::new();
+        let mut reverse_map = HashMap::new();
+
+        for (idx, species) in species_list.into_iter().enumerate() {
+            species_map.insert(species.clone(), idx);
+            reverse_map.insert(idx, species);
+        }
+
+        Self {
+            species_map,
+            reverse_map,
+        }
+    }
+
+    pub fn species_to_id(&self, species: &str) -> Option<usize> {
+        self.species_map.get(species).copied()
+    }
+
+    pub fn id_to_species(&self, id: usize) -> Option<&String> {
+        self.reverse_map.get(&id)
+    }
+
+    pub fn num_species(&self) -> usize {
+        self.species_map.len()
+    }
+}
+
+/// Body plan classifier utility
+pub struct BodyPlanClassifier;
+
+impl BodyPlanClassifier {
+    pub fn body_plan_to_id(body_plan: &BodyPlan) -> usize {
+        match body_plan {
+            BodyPlan::Quadruped => 0,
+            BodyPlan::Biped => 1,
+            BodyPlan::Bird => 2,
+            BodyPlan::Snake => 3,
+            BodyPlan::Fish => 4,
+            BodyPlan::Insect => 5,
+            BodyPlan::Spider => 6,
+            BodyPlan::Custom(_) => 7,
+        }
+    }
+
+    pub fn id_to_body_plan(id: usize) -> Option<BodyPlan> {
+        match id {
+            0 => Some(BodyPlan::Quadruped),
+            1 => Some(BodyPlan::Biped),
+            2 => Some(BodyPlan::Bird),
+            3 => Some(BodyPlan::Snake),
+            4 => Some(BodyPlan::Fish),
+            5 => Some(BodyPlan::Insect),
+            6 => Some(BodyPlan::Spider),
+            _ => None,
+        }
+    }
+
+    pub fn num_body_plans() -> usize {
+        8
+    }
+}
+

--- a/src/morphnet/mod.rs
+++ b/src/morphnet/mod.rs
@@ -1,0 +1,458 @@
+//! MorphNet: Geometric Template Learning for Structural Understanding
+
+pub mod model;
+pub mod templates;
+pub mod classification;
+pub mod training;
+
+pub use model::*;
+pub use templates::*;
+pub use classification::*;
+pub use training::*;
+
+use ndarray::{Array1, Array2, Array3};
+use nalgebra::{Point3, Vector3};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Core MorphNet framework error types
+#[derive(thiserror::Error, Debug)]
+pub enum MorphNetError {
+    #[error("Template error: {0}")]
+    Template(String),
+    #[error("Classification error: {0}")]
+    Classification(String),
+    #[error("Training error: {0}")]
+    Training(String),
+    #[error("Model error: {0}")]
+    Model(String),
+    #[error("Data processing error: {0}")]
+    DataProcessing(String),
+    #[error("Validation error: {0}")]
+    Validation(String),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] bincode::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+/// Result type for MorphNet operations
+pub type Result<T> = std::result::Result<T, MorphNetError>;
+
+/// Supported body plan types
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum BodyPlan {
+    Quadruped,
+    Biped,
+    Bird,
+    Snake,
+    Fish,
+    Insect,
+    Spider,
+    Custom(String),
+}
+
+impl std::fmt::Display for BodyPlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BodyPlan::Quadruped => write!(f, "quadruped"),
+            BodyPlan::Biped => write!(f, "biped"),
+            BodyPlan::Bird => write!(f, "bird"),
+            BodyPlan::Snake => write!(f, "snake"),
+            BodyPlan::Fish => write!(f, "fish"),
+            BodyPlan::Insect => write!(f, "insect"),
+            BodyPlan::Spider => write!(f, "spider"),
+            BodyPlan::Custom(name) => write!(f, "{}", name),
+        }
+    }
+}
+
+/// Types of anatomical landmarks
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AnatomicalType {
+    Head,
+    Neck,
+    Torso,
+    Limb,
+    Joint,
+    Extremity,
+    Tail,
+    Wing,
+    Fin,
+    Custom(String),
+}
+
+/// Connection types between keypoints
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ConnectionType {
+    Bone,
+    Joint,
+    Muscle,
+    Surface,
+}
+
+/// Geometric keypoint in 3D space
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Keypoint {
+    pub name: String,
+    pub position: Point3<f32>,
+    pub confidence: f32,
+    pub visibility: bool,
+    pub anatomical_type: AnatomicalType,
+}
+
+/// Connection between keypoints forming structural relationships
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Connection {
+    pub from: String,
+    pub to: String,
+    pub connection_type: ConnectionType,
+    pub strength: f32,
+}
+
+/// Structural constraints for template validation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum StructuralConstraint {
+    Distance {
+        from: String,
+        to: String,
+        min_distance: f32,
+        max_distance: f32,
+    },
+    Angle {
+        vertex: String,
+        arm1: String,
+        arm2: String,
+        min_angle: f32,
+        max_angle: f32,
+    },
+    Ordering {
+        points: Vec<String>,
+        axis: Vector3<f32>,
+    },
+}
+
+/// Symmetry properties of templates
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SymmetryType {
+    None,
+    Bilateral,
+    Radial { n_fold: u32 },
+    Helical,
+}
+
+/// Learnable parameters for template adaptation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TemplateParameters {
+    pub scale_factors: HashMap<String, f32>,
+    pub proportions: HashMap<String, f32>,
+    pub flexibility: HashMap<String, f32>,
+    pub adaptations: HashMap<String, f32>,
+}
+
+impl Default for TemplateParameters {
+    fn default() -> Self {
+        Self {
+            scale_factors: HashMap::new(),
+            proportions: HashMap::new(),
+            flexibility: HashMap::new(),
+            adaptations: HashMap::new(),
+        }
+    }
+}
+
+/// Core geometric template defining a body plan
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeometricTemplate {
+    pub name: String,
+    pub body_plan: BodyPlan,
+    pub keypoints: HashMap<String, Keypoint>,
+    pub connections: Vec<Connection>,
+    pub constraints: Vec<StructuralConstraint>,
+    pub symmetry: SymmetryType,
+    pub scale_invariant: bool,
+    pub parameters: TemplateParameters,
+}
+
+impl GeometricTemplate {
+    /// Create a new geometric template
+    pub fn new(name: String, body_plan: BodyPlan) -> Self {
+        Self {
+            name,
+            body_plan,
+            keypoints: HashMap::new(),
+            connections: Vec::new(),
+            constraints: Vec::new(),
+            symmetry: SymmetryType::None,
+            scale_invariant: true,
+            parameters: TemplateParameters::default(),
+        }
+    }
+
+    /// Add a keypoint to the template
+    pub fn add_keypoint(&mut self, keypoint: Keypoint) {
+        self.keypoints.insert(keypoint.name.clone(), keypoint);
+    }
+
+    /// Add a connection between keypoints
+    pub fn add_connection(&mut self, connection: Connection) -> Result<()> {
+        if !self.keypoints.contains_key(&connection.from) {
+            return Err(MorphNetError::Template(format!(
+                "Keypoint '{}' not found",
+                connection.from
+            )));
+        }
+        if !self.keypoints.contains_key(&connection.to) {
+            return Err(MorphNetError::Template(format!(
+                "Keypoint '{}' not found",
+                connection.to
+            )));
+        }
+
+        self.connections.push(connection);
+        Ok(())
+    }
+
+    /// Validate template structure against constraints
+    pub fn validate(&self) -> Result<()> {
+        for constraint in &self.constraints {
+            match constraint {
+                StructuralConstraint::Distance { from, to, min_distance, max_distance } => {
+                    let p1 = self.keypoints.get(from).ok_or_else(|| {
+                        MorphNetError::Template(format!("Keypoint '{}' not found", from))
+                    })?;
+                    let p2 = self.keypoints.get(to).ok_or_else(|| {
+                        MorphNetError::Template(format!("Keypoint '{}' not found", to))
+                    })?;
+
+                    let distance = (p1.position - p2.position).norm();
+                    if distance < *min_distance || distance > *max_distance {
+                        return Err(MorphNetError::Validation(format!(
+                            "Distance constraint violated between {} and {}: {} not in [{}, {}]",
+                            from, to, distance, min_distance, max_distance
+                        )));
+                    }
+                }
+                StructuralConstraint::Angle { vertex, arm1, arm2, min_angle, max_angle } => {
+                    let v = self.keypoints.get(vertex).ok_or_else(|| {
+                        MorphNetError::Template(format!("Vertex '{}' not found", vertex))
+                    })?;
+                    let a1 = self.keypoints.get(arm1).ok_or_else(|| {
+                        MorphNetError::Template(format!("Arm1 '{}' not found", arm1))
+                    })?;
+                    let a2 = self.keypoints.get(arm2).ok_or_else(|| {
+                        MorphNetError::Template(format!("Arm2 '{}' not found", arm2))
+                    })?;
+
+                    let vec1 = (a1.position - v.position).normalize();
+                    let vec2 = (a2.position - v.position).normalize();
+                    let angle = vec1.dot(&vec2).acos();
+
+                    if angle < *min_angle || angle > *max_angle {
+                        return Err(MorphNetError::Validation(format!(
+                            "Angle constraint violated at {}: {} not in [{}, {}]",
+                            vertex, angle, min_angle, max_angle
+                        )));
+                    }
+                }
+                StructuralConstraint::Ordering { points, axis } => {
+                    let mut projections: Vec<(String, f32)> = Vec::new();
+                    for name in points {
+                        let point = self.keypoints.get(name).ok_or_else(|| {
+                            MorphNetError::Template(format!("Keypoint '{}' not found", name))
+                        })?;
+                        let projection = point.position.coords.dot(axis);
+                        projections.push((name.clone(), projection));
+                    }
+
+                    projections.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+
+                    let ordered_names: Vec<String> =
+                        projections.into_iter().map(|(name, _)| name).collect();
+                    if ordered_names != *points {
+                        return Err(MorphNetError::Validation(format!(
+                            "Ordering constraint violated: expected {:?}, got {:?}",
+                            points, ordered_names
+                        )));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Apply learned parameters to adapt template
+    pub fn apply_parameters(&mut self, params: &TemplateParameters) {
+        self.parameters = params.clone();
+
+        for (name, keypoint) in &mut self.keypoints {
+            if let Some(&scale) = params.scale_factors.get(name) {
+                keypoint.position = keypoint.position * scale;
+            }
+        }
+    }
+
+    /// Generate parameter vector for ML training
+    pub fn to_parameter_vector(&self) -> Array1<f32> {
+        let mut params = Vec::new();
+
+        for keypoint in self.keypoints.values() {
+            params.extend_from_slice(keypoint.position.coords.as_slice());
+        }
+
+        for value in self.parameters.scale_factors.values() {
+            params.push(*value);
+        }
+        for value in self.parameters.proportions.values() {
+            params.push(*value);
+        }
+        for value in self.parameters.flexibility.values() {
+            params.push(*value);
+        }
+
+        Array1::from_vec(params)
+    }
+
+    /// Reconstruct template from parameter vector
+    pub fn from_parameter_vector(&mut self, params: &Array1<f32>) -> Result<()> {
+        let mut idx = 0;
+
+        for keypoint in self.keypoints.values_mut() {
+            if idx + 3 > params.len() {
+                return Err(MorphNetError::DataProcessing(
+                    "Parameter vector too short".to_string(),
+                ));
+            }
+            keypoint.position = Point3::new(params[idx], params[idx + 1], params[idx + 2]);
+            idx += 3;
+        }
+
+        Ok(())
+    }
+
+    /// Get the number of keypoints
+    pub fn keypoint_count(&self) -> usize {
+        self.keypoints.len()
+    }
+
+    /// Get the number of connections
+    pub fn connection_count(&self) -> usize {
+        self.connections.len()
+    }
+
+    /// Check if template has a specific keypoint
+    pub fn has_keypoint(&self, name: &str) -> bool {
+        self.keypoints.contains_key(name)
+    }
+
+    /// Get keypoint by name
+    pub fn get_keypoint(&self, name: &str) -> Option<&Keypoint> {
+        self.keypoints.get(name)
+    }
+
+    /// Get all keypoint names
+    pub fn keypoint_names(&self) -> Vec<String> {
+        self.keypoints.keys().cloned().collect()
+    }
+
+    /// Calculate bounding box of all keypoints
+    pub fn bounding_box(&self) -> Option<(Point3<f32>, Point3<f32>)> {
+        if self.keypoints.is_empty() {
+            return None;
+        }
+
+        let positions: Vec<Point3<f32>> = self.keypoints.values().map(|k| k.position).collect();
+
+        let min_x = positions.iter().map(|p| p.x).fold(f32::INFINITY, f32::min);
+        let min_y = positions.iter().map(|p| p.y).fold(f32::INFINITY, f32::min);
+        let min_z = positions.iter().map(|p| p.z).fold(f32::INFINITY, f32::min);
+
+        let max_x = positions.iter().map(|p| p.x).fold(f32::NEG_INFINITY, f32::max);
+        let max_y = positions.iter().map(|p| p.y).fold(f32::NEG_INFINITY, f32::max);
+        let max_z = positions.iter().map(|p| p.z).fold(f32::NEG_INFINITY, f32::max);
+
+        Some((
+            Point3::new(min_x, min_y, min_z),
+            Point3::new(max_x, max_y, max_z),
+        ))
+    }
+
+    /// Calculate centroid of all keypoints
+    pub fn centroid(&self) -> Option<Point3<f32>> {
+        if self.keypoints.is_empty() {
+            return None;
+        }
+
+        let sum = self
+            .keypoints
+            .values()
+            .map(|k| k.position.coords)
+            .fold(Vector3::zeros(), |acc, pos| acc + pos);
+
+        let count = self.keypoints.len() as f32;
+        Some(Point3::from(sum / count))
+    }
+}
+
+/// Classification results from MorphNet
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassificationResult {
+    pub species_probs: HashMap<String, f32>,
+    pub body_plan_probs: HashMap<BodyPlan, f32>,
+    pub predicted_species: String,
+    pub predicted_body_plan: BodyPlan,
+    pub species_confidence: f32,
+    pub body_plan_confidence: f32,
+    pub template_parameters: Array1<f32>,
+    pub template: GeometricTemplate,
+}
+
+/// Configuration for MorphNet model
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MorphNetConfig {
+    pub num_species: usize,
+    pub feature_dim: usize,
+    pub template_param_dim: usize,
+    pub learning_rate: f64,
+    pub dropout_rate: f64,
+    pub input_size: (usize, usize),
+}
+
+impl Default for MorphNetConfig {
+    fn default() -> Self {
+        Self {
+            num_species: 100,
+            feature_dim: 2048,
+            template_param_dim: 256,
+            learning_rate: 1e-4,
+            dropout_rate: 0.5,
+            input_size: (224, 224),
+        }
+    }
+}
+
+/// Training metrics for MorphNet
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrainingMetrics {
+    pub epoch: usize,
+    pub species_loss: f32,
+    pub body_plan_loss: f32,
+    pub template_loss: f32,
+    pub total_loss: f32,
+    pub species_accuracy: f32,
+    pub body_plan_accuracy: f32,
+    pub template_error: f32,
+}
+
+/// Validation results
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationResults {
+    pub metrics: TrainingMetrics,
+    pub confusion_matrix: HashMap<String, HashMap<String, usize>>,
+    pub per_class_accuracy: HashMap<String, f32>,
+    pub template_alignment_error: f32,
+}
+
+

--- a/src/morphnet/model.rs
+++ b/src/morphnet/model.rs
@@ -1,0 +1,95 @@
+//! MorphNet Core Model Implementation
+
+use super::*;
+
+/// Main MorphNet neural network (placeholder implementation)
+pub struct MorphNet {
+    config: MorphNetConfig,
+    templates: HashMap<BodyPlan, GeometricTemplate>,
+}
+
+impl MorphNet {
+    /// Create a new MorphNet model
+    pub fn new(config: MorphNetConfig) -> Result<Self> {
+        let templates = TemplateFactory::get_all_templates();
+        Ok(Self { config, templates })
+    }
+
+    /// Classify input image and predict template
+    pub fn classify(&self, _image: &Array3<f32>) -> Result<ClassificationResult> {
+        let predicted_body_plan = BodyPlan::Quadruped;
+        let template = self
+            .templates
+            .get(&predicted_body_plan)
+            .ok_or_else(|| MorphNetError::Model("Template not found".to_string()))?
+            .clone();
+
+        Ok(ClassificationResult {
+            species_probs: {
+                let mut probs = HashMap::new();
+                probs.insert("example_species".to_string(), 0.9);
+                probs
+            },
+            body_plan_probs: {
+                let mut probs = HashMap::new();
+                probs.insert(predicted_body_plan.clone(), 0.95);
+                probs
+            },
+            predicted_species: "example_species".to_string(),
+            predicted_body_plan,
+            species_confidence: 0.9,
+            body_plan_confidence: 0.95,
+            template_parameters: Array1::zeros(10),
+            template,
+        })
+    }
+
+    /// Get model configuration
+    pub fn config(&self) -> &MorphNetConfig {
+        &self.config
+    }
+
+    /// Get available templates
+    pub fn templates(&self) -> &HashMap<BodyPlan, GeometricTemplate> {
+        &self.templates
+    }
+}
+
+/// Model builder for easy configuration
+pub struct MorphNetBuilder {
+    config: MorphNetConfig,
+}
+
+impl MorphNetBuilder {
+    pub fn new() -> Self {
+        Self {
+            config: MorphNetConfig::default(),
+        }
+    }
+
+    pub fn with_num_species(mut self, num_species: usize) -> Self {
+        self.config.num_species = num_species;
+        self
+    }
+
+    pub fn with_learning_rate(mut self, lr: f64) -> Self {
+        self.config.learning_rate = lr;
+        self
+    }
+
+    pub fn with_dropout_rate(mut self, dropout: f64) -> Self {
+        self.config.dropout_rate = dropout;
+        self
+    }
+
+    pub fn build(self) -> Result<MorphNet> {
+        MorphNet::new(self.config)
+    }
+}
+
+impl Default for MorphNetBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+

--- a/src/morphnet/templates.rs
+++ b/src/morphnet/templates.rs
@@ -1,0 +1,259 @@
+//! Template Factory and Management
+
+use super::*;
+
+/// Template factory for creating standard body plans
+pub struct TemplateFactory;
+
+impl TemplateFactory {
+    /// Create a quadruped template
+    pub fn create_quadruped() -> GeometricTemplate {
+        let mut template = GeometricTemplate::new("quadruped".to_string(), BodyPlan::Quadruped);
+
+        // Add keypoints
+        template.add_keypoint(Keypoint {
+            name: "nose".to_string(),
+            position: Point3::new(0.0, 0.0, 1.0),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Head,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "head".to_string(),
+            position: Point3::new(0.0, 0.0, 0.8),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Head,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "neck".to_string(),
+            position: Point3::new(0.0, 0.0, 0.6),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Neck,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "shoulder_left".to_string(),
+            position: Point3::new(-0.3, 0.0, 0.5),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Joint,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "shoulder_right".to_string(),
+            position: Point3::new(0.3, 0.0, 0.5),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Joint,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "spine".to_string(),
+            position: Point3::new(0.0, 0.0, 0.0),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Torso,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "hip_left".to_string(),
+            position: Point3::new(-0.25, 0.0, -0.3),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Joint,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "hip_right".to_string(),
+            position: Point3::new(0.25, 0.0, -0.3),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Joint,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "tail".to_string(),
+            position: Point3::new(0.0, 0.0, -0.7),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Tail,
+        });
+
+        for side in ["left", "right"] {
+            for position in ["front", "back"] {
+                let x = if side == "left" { -0.3 } else { 0.3 };
+                let z = if position == "front" { 0.2 } else { -0.5 };
+
+                template.add_keypoint(Keypoint {
+                    name: format!("paw_{}_{}", position, side),
+                    position: Point3::new(x, -0.6, z),
+                    confidence: 1.0,
+                    visibility: true,
+                    anatomical_type: AnatomicalType::Extremity,
+                });
+            }
+        }
+
+        let connections = vec![
+            ("head", "nose"),
+            ("neck", "head"),
+            ("shoulder_left", "neck"),
+            ("shoulder_right", "neck"),
+            ("spine", "neck"),
+            ("hip_left", "spine"),
+            ("hip_right", "spine"),
+            ("tail", "spine"),
+            ("shoulder_left", "paw_front_left"),
+            ("shoulder_right", "paw_front_right"),
+            ("hip_left", "paw_back_left"),
+            ("hip_right", "paw_back_right"),
+        ];
+
+        for (from, to) in connections {
+            template
+                .add_connection(Connection {
+                    from: from.to_string(),
+                    to: to.to_string(),
+                    connection_type: ConnectionType::Bone,
+                    strength: 1.0,
+                })
+                .unwrap();
+        }
+
+        template.symmetry = SymmetryType::Bilateral;
+        template
+    }
+
+    /// Create a bird template
+    pub fn create_bird() -> GeometricTemplate {
+        let mut template = GeometricTemplate::new("bird".to_string(), BodyPlan::Bird);
+
+        template.add_keypoint(Keypoint {
+            name: "beak".to_string(),
+            position: Point3::new(0.0, 0.0, 0.8),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Head,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "head".to_string(),
+            position: Point3::new(0.0, 0.0, 0.6),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Head,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "neck".to_string(),
+            position: Point3::new(0.0, 0.0, 0.3),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Neck,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "breast".to_string(),
+            position: Point3::new(0.0, 0.0, 0.0),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Torso,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "wing_left".to_string(),
+            position: Point3::new(-0.5, 0.0, 0.0),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Wing,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "wing_right".to_string(),
+            position: Point3::new(0.5, 0.0, 0.0),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Wing,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "body".to_string(),
+            position: Point3::new(0.0, 0.0, -0.3),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Torso,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "tail".to_string(),
+            position: Point3::new(0.0, 0.0, -0.8),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Tail,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "leg_left".to_string(),
+            position: Point3::new(-0.15, -0.4, -0.2),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Limb,
+        });
+
+        template.add_keypoint(Keypoint {
+            name: "leg_right".to_string(),
+            position: Point3::new(0.15, -0.4, -0.2),
+            confidence: 1.0,
+            visibility: true,
+            anatomical_type: AnatomicalType::Limb,
+        });
+
+        let connections = vec![
+            ("head", "beak"),
+            ("neck", "head"),
+            ("breast", "neck"),
+            ("wing_left", "breast"),
+            ("wing_right", "breast"),
+            ("body", "breast"),
+            ("tail", "body"),
+            ("leg_left", "body"),
+            ("leg_right", "body"),
+        ];
+
+        for (from, to) in connections {
+            template
+                .add_connection(Connection {
+                    from: from.to_string(),
+                    to: to.to_string(),
+                    connection_type: ConnectionType::Bone,
+                    strength: 1.0,
+                })
+                .unwrap();
+        }
+
+        template.symmetry = SymmetryType::Bilateral;
+        template
+    }
+
+    /// Get all available templates
+    pub fn get_all_templates() -> HashMap<BodyPlan, GeometricTemplate> {
+        let mut templates = HashMap::new();
+        templates.insert(BodyPlan::Quadruped, Self::create_quadruped());
+        templates.insert(BodyPlan::Bird, Self::create_bird());
+        templates
+    }
+
+    /// Create a template for a specific body plan
+    pub fn create_template(body_plan: &BodyPlan) -> Option<GeometricTemplate> {
+        match body_plan {
+            BodyPlan::Quadruped => Some(Self::create_quadruped()),
+            BodyPlan::Bird => Some(Self::create_bird()),
+            _ => None,
+        }
+    }
+}
+

--- a/src/morphnet/training.rs
+++ b/src/morphnet/training.rs
@@ -1,0 +1,186 @@
+//! Training utilities and procedures
+
+use super::*;
+
+/// Training configuration
+#[derive(Debug, Clone)]
+pub struct TrainingConfig {
+    pub batch_size: usize,
+    pub learning_rate: f64,
+    pub num_epochs: usize,
+    pub validation_split: f32,
+    pub early_stopping_patience: usize,
+    pub checkpoint_interval: usize,
+}
+
+impl Default for TrainingConfig {
+    fn default() -> Self {
+        Self {
+            batch_size: 32,
+            learning_rate: 1e-4,
+            num_epochs: 100,
+            validation_split: 0.2,
+            early_stopping_patience: 10,
+            checkpoint_interval: 5,
+        }
+    }
+}
+
+/// Training state tracker
+#[derive(Debug, Clone)]
+pub struct TrainingState {
+    pub epoch: usize,
+    pub best_validation_loss: f32,
+    pub patience_counter: usize,
+    pub training_history: Vec<TrainingMetrics>,
+    pub validation_history: Vec<ValidationResults>,
+}
+
+impl TrainingState {
+    pub fn new() -> Self {
+        Self {
+            epoch: 0,
+            best_validation_loss: f32::INFINITY,
+            patience_counter: 0,
+            training_history: Vec::new(),
+            validation_history: Vec::new(),
+        }
+    }
+
+    pub fn update(&mut self, metrics: TrainingMetrics, validation: ValidationResults) {
+        self.epoch += 1;
+
+        if validation.metrics.total_loss < self.best_validation_loss {
+            self.best_validation_loss = validation.metrics.total_loss;
+            self.patience_counter = 0;
+        } else {
+            self.patience_counter += 1;
+        }
+
+        self.training_history.push(metrics);
+        self.validation_history.push(validation);
+    }
+
+    pub fn should_stop(&self, patience: usize) -> bool {
+        self.patience_counter >= patience
+    }
+}
+
+/// Training data loader (placeholder)
+pub struct DataLoader {
+    data: Vec<(Array3<f32>, String, BodyPlan)>,
+    batch_size: usize,
+    current_idx: usize,
+}
+
+impl DataLoader {
+    pub fn new(data: Vec<(Array3<f32>, String, BodyPlan)>, batch_size: usize) -> Self {
+        Self {
+            data,
+            batch_size,
+            current_idx: 0,
+        }
+    }
+
+    pub fn next_batch(&mut self) -> Option<Vec<(Array3<f32>, String, BodyPlan)>> {
+        if self.current_idx >= self.data.len() {
+            return None;
+        }
+
+        let end_idx = std::cmp::min(self.current_idx + self.batch_size, self.data.len());
+        let batch = self.data[self.current_idx..end_idx].to_vec();
+        self.current_idx = end_idx;
+        Some(batch)
+    }
+
+    pub fn reset(&mut self) {
+        self.current_idx = 0;
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+/// Training utilities
+pub struct Trainer {
+    config: TrainingConfig,
+    state: TrainingState,
+}
+
+impl Trainer {
+    pub fn new(config: TrainingConfig) -> Self {
+        Self {
+            config,
+            state: TrainingState::new(),
+        }
+    }
+
+    /// Train the model (placeholder implementation)
+    pub fn train(
+        &mut self,
+        model: &mut MorphNet,
+        train_loader: DataLoader,
+        val_loader: DataLoader,
+    ) -> Result<()> {
+        for epoch in 0..self.config.num_epochs {
+            println!("Epoch {}/{}", epoch + 1, self.config.num_epochs);
+            let train_metrics = self.train_epoch(model, &train_loader)?;
+            let val_results = self.validate_epoch(model, &val_loader)?;
+            self.state.update(train_metrics, val_results);
+            if self.state.should_stop(self.config.early_stopping_patience) {
+                println!("Early stopping triggered at epoch {}", epoch + 1);
+                break;
+            }
+            if epoch % self.config.checkpoint_interval == 0 {
+                self.save_checkpoint(model, epoch)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn train_epoch(&self, _model: &mut MorphNet, _loader: &DataLoader) -> Result<TrainingMetrics> {
+        Ok(TrainingMetrics {
+            epoch: self.state.epoch + 1,
+            species_loss: 0.5,
+            body_plan_loss: 0.3,
+            template_loss: 0.2,
+            total_loss: 1.0,
+            species_accuracy: 0.85,
+            body_plan_accuracy: 0.92,
+            template_error: 0.15,
+        })
+    }
+
+    fn validate_epoch(&self, _model: &MorphNet, _loader: &DataLoader) -> Result<ValidationResults> {
+        Ok(ValidationResults {
+            metrics: TrainingMetrics {
+                epoch: self.state.epoch + 1,
+                species_loss: 0.6,
+                body_plan_loss: 0.35,
+                template_loss: 0.25,
+                total_loss: 1.2,
+                species_accuracy: 0.82,
+                body_plan_accuracy: 0.90,
+                template_error: 0.18,
+            },
+            confusion_matrix: HashMap::new(),
+            per_class_accuracy: HashMap::new(),
+            template_alignment_error: 0.12,
+        })
+    }
+
+    fn save_checkpoint(&self, _model: &MorphNet, epoch: usize) -> Result<()> {
+        println!("Saving checkpoint at epoch {}", epoch);
+        Ok(())
+    }
+
+    pub fn get_training_state(&self) -> &TrainingState {
+        &self.state
+    }
+}
+


### PR DESCRIPTION
## Summary
- avoid divide by zero and mismatched lengths in `ClassificationMetrics::calculate`

## Testing
- `cargo check`
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68408a2805248330866f238ac4da9cb9