### PR TITLE
Fix README docs links

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,28 @@
+# Getting Started Guide
+
+Welcome to MorphNet! This guide will help you set up and run basic examples.
+
+## Installation
+
+Add the crate to your `Cargo.toml`:
+
+```toml
+morphnet-gtl = "0.1"
+```
+
+Then build the project:
+
+```bash
+cargo build
+```
+
+## Basic Example
+
+To see MorphNet in action, run:
+
+```bash
+cargo run --example mmx_demo
+```
+
+This will generate a demo using the MMX format.
+

--- a/docs/mmx-format.md
+++ b/docs/mmx-format.md
@@ -1,0 +1,10 @@
+# MMX Format Specification
+
+The MMX format stores multimodal tensors used throughout MorphNet. This
+document provides a high-level overview of the format. A full reference is
+in progress.
+
+## File Layout
+
+Each MMX file begins with a header describing the contained tensor stack,
+followed by compressed data blocks.

--- a/docs/papers/mmx-format.pdf
+++ b/docs/papers/mmx-format.pdf
@@ -1,0 +1,51 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog
+   /Pages 2 0 R
+>>
+endobj
+2 0 obj
+<< /Type /Pages
+   /Kids [3 0 R]
+   /Count 1
+>>
+endobj
+3 0 obj
+<< /Type /Page
+   /Parent 2 0 R
+   /MediaBox [0 0 612 792]
+   /Contents 4 0 R
+   /Resources << /Font << /F1 5 0 R >> >>
+>>
+endobj
+4 0 obj
+<< /Length 51 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(MMX format paper placeholder) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font
+   /Subtype /Type1
+   /BaseFont /Helvetica
+>>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000061 00000 n 
+0000000114 00000 n 
+0000000212 00000 n 
+0000000351 00000 n 
+trailer
+<< /Root 1 0 R
+   /Size 6
+>>
+startxref
+433
+%%EOF

--- a/docs/papers/morphnet-gtl.pdf
+++ b/docs/papers/morphnet-gtl.pdf
@@ -1,0 +1,51 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog
+   /Pages 2 0 R
+>>
+endobj
+2 0 obj
+<< /Type /Pages
+   /Kids [3 0 R]
+   /Count 1
+>>
+endobj
+3 0 obj
+<< /Type /Page
+   /Parent 2 0 R
+   /MediaBox [0 0 612 792]
+   /Contents 4 0 R
+   /Resources << /Font << /F1 5 0 R >> >>
+>>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(MorphNet GTL paper placeholder) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font
+   /Subtype /Type1
+   /BaseFont /Helvetica
+>>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000061 00000 n 
+0000000114 00000 n 
+0000000220 00000 n 
+0000000359 00000 n 
+trailer
+<< /Root 1 0 R
+   /Size 6
+>>
+startxref
+445
+%%EOF

--- a/docs/spatial-monitoring.md
+++ b/docs/spatial-monitoring.md
@@ -1,0 +1,7 @@
+# Spatial Monitoring Setup
+
+Spatial monitoring records template fits over time. To enable monitoring:
+
+1. Set `enable_monitoring` when creating the `MorphSession`.
+2. Specify an output directory for logs.
+3. Review the generated MMX files with the provided tools.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,9 @@
+# Template Creation
+
+This document outlines how to create new geometric templates for MorphNet.
+
+1. Define keypoints for your structure.
+2. Use the provided helper methods to generate template meshes.
+3. Validate your template with the built-in checks.
+
+For more details, see the examples in the repository.


### PR DESCRIPTION
## Summary
- restore README links to doc files
- add placeholder docs for tutorials and papers

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68414d64ed9083308ddd524211920a98