### PR TITLE
Implement simple brightness-based classification

### DIFF
--- a/src/morphnet/classification.rs
+++ b/src/morphnet/classification.rs
@@ -8,10 +8,19 @@ pub struct ClassificationResult {
     pub confidence: f32,
 }
 
-pub fn classify(_net: &MorphNet, _input: &TensorData) -> Result<ClassificationResult> {
-    // Placeholder classification routine
-    Ok(ClassificationResult {
-        label: "unknown".to_string(),
-        confidence: 0.0,
-    })
+pub fn classify(net: &MorphNet, input: &TensorData) -> Result<ClassificationResult> {
+    // Simple brightness based classifier used as an example implementation.
+    let sum: f32 = input.data.iter().copied().sum();
+    let mean = if input.data.len() > 0 {
+        sum / input.data.len() as f32
+    } else { 0.0 };
+
+    let threshold = net.brightness_threshold;
+    let (label, confidence) = if mean >= threshold {
+        ("light", (mean - threshold).min(1.0))
+    } else {
+        ("dark", (threshold - mean).min(1.0))
+    };
+
+    Ok(ClassificationResult { label: label.to_string(), confidence })
 }

--- a/src/morphnet/training.rs
+++ b/src/morphnet/training.rs
@@ -1,7 +1,20 @@
 use super::*;
 use crate::TensorData;
 
-pub fn train(_net: &mut MorphNet, _data: &[TensorData]) -> Result<()> {
-    // Placeholder training routine
+pub fn train(net: &mut MorphNet, data: &[TensorData]) -> Result<()> {
+    // Extremely small example "training" that adjusts the brightness threshold
+    // based on the mean brightness of the provided dataset.
+    if data.is_empty() {
+        return Ok(());
+    }
+
+    let mut total = 0.0;
+    for t in data {
+        let sum: f32 = t.data.iter().copied().sum();
+        if t.data.len() > 0 {
+            total += sum / t.data.len() as f32;
+        }
+    }
+    net.brightness_threshold = total / data.len() as f32;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- implement a minimal working classifier using average brightness
- expose a brightness threshold in `MorphNet` and builder
- add a trivial training routine to set the threshold
- wire `MorphNet::classify` to the new classifier

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6841cc2c97508330a321ab76327e20fe