### PR TITLE
Introduce logistic regression classifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "argmin"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523c0b5258fa1fb9072748b7306fb0db1625cf235ec6da4d05de2560ef56f882"
+dependencies = [
+ "anyhow",
+ "argmin-math",
+ "bincode",
+ "instant",
+ "num-traits",
+ "paste",
+ "rand 0.8.5",
+ "rand_xoshiro",
+ "serde",
+ "serde_json",
+ "slog-json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "argmin-math"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8798ca7447753fcb3dd98d9095335b1564812a68c6e7c3d1926e1d5cf094e37"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "ndarray",
+ "num-complex 0.4.6",
+ "num-integer",
+ "num-traits",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1087,15 @@ name = "custom_derive"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -1961,6 +2006,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,6 +2178,7 @@ dependencies = [
  "ndarray",
  "num-traits",
  "rand 0.8.5",
+ "serde",
  "sprs",
  "thiserror 1.0.69",
 ]
@@ -2169,6 +2224,22 @@ dependencies = [
  "ndarray",
  "num-traits",
  "rand 0.8.5",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "linfa-logistic"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0999b10c6809fe8fd1e22bfc898b7901ec61947b260517ca1d4f6d90524d3df9"
+dependencies = [
+ "argmin",
+ "argmin-math",
+ "linfa",
+ "ndarray",
+ "ndarray-stats",
+ "num-traits",
+ "serde",
  "thiserror 1.0.69",
 ]
 
@@ -2350,6 +2421,7 @@ dependencies = [
  "imageproc",
  "linfa",
  "linfa-clustering",
+ "linfa-logistic",
  "linfa-reduction",
  "lz4_flex",
  "memmap2",
@@ -2473,6 +2545,7 @@ dependencies = [
  "num-traits",
  "rawpointer",
  "rayon",
+ "serde",
 ]
 
 [[package]]
@@ -2611,6 +2684,12 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -3199,6 +3278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3296,6 +3381,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -3334,6 +3420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+ "serde",
 ]
 
 [[package]]
@@ -3371,6 +3458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -3702,6 +3790,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+
+[[package]]
+name = "slog-json"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1e53f61af1e3c8b852eef0a9dee29008f55d6dd63794f3f12cef786cf0f219"
+dependencies = [
+ "serde",
+ "serde_json",
+ "slog",
+ "time",
+]
+
+[[package]]
 name = "slotmap"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3964,6 +4070,37 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ statrs = "0.16"
 linfa = "0.7"
 linfa-clustering = "0.7"
 linfa-reduction = "0.7"
+linfa-logistic = { version = "0.7", features = ["serde"] }
 
 # Utilities
 uuid = { version = "1.0", features = ["v4", "serde"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub mod prelude {
         GeometricTemplate, TemplateFactory, SpatialConfig,
         GeometricParameters, GeometricTemplateData, ExtendedBodyPlan,
     };
+    pub use crate::morphnet::{train, train_logistic};
     pub use ndarray::{Array, Array1, Array2, Array3, ArrayD};
     pub use nalgebra::{Point3, Vector3, Matrix3, Matrix4};
 }

--- a/src/morphnet/classification.rs
+++ b/src/morphnet/classification.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::TensorData;
 use serde::{Serialize, Deserialize};
+use linfa::prelude::*;
+use ndarray::Array2;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClassificationResult {
@@ -9,7 +11,18 @@ pub struct ClassificationResult {
 }
 
 pub fn classify(net: &MorphNet, input: &TensorData) -> Result<ClassificationResult> {
-    // Simple brightness based classifier used as an example implementation.
+    if let Some(model) = &net.logistic_model {
+        let flat = input.data.iter().map(|v| *v as f64).collect::<Vec<_>>();
+        let arr = Array2::from_shape_vec((1, flat.len()), flat)
+            .map_err(|e| MorphNetError::Classification(e.to_string()))?;
+        let pred = model.predict(&arr);
+        let probs = model.predict_probabilities(&arr);
+        let label = pred[0].to_string();
+        let confidence = probs[0] as f32;
+        return Ok(ClassificationResult { label, confidence });
+    }
+
+    // Fallback simple brightness-based classifier
     let sum: f32 = input.data.iter().copied().sum();
     let mean = if input.data.len() > 0 {
         sum / input.data.len() as f32

--- a/src/morphnet/model.rs
+++ b/src/morphnet/model.rs
@@ -3,6 +3,7 @@ use serde::{Serialize, Deserialize};
 use std::collections::HashMap;
 use ndarray::Array3;
 use crate::TensorData;
+use linfa_logistic::FittedLogisticRegression;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Device {
@@ -35,6 +36,7 @@ impl MorphNetBuilder {
         Ok(MorphNet {
             body_plan: BodyPlanModel { templates: Vec::new() },
             brightness_threshold: self.config.brightness_threshold,
+            logistic_model: None,
         })
     }
 }
@@ -120,6 +122,9 @@ pub struct MorphNet {
     pub body_plan: BodyPlanModel,
     /// Threshold used for basic brightness classification
     pub brightness_threshold: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub logistic_model: Option<FittedLogisticRegression<f64, usize>>,
 }
 
 impl MorphNet {
@@ -127,6 +132,7 @@ impl MorphNet {
         Self {
             body_plan: BodyPlanModel { templates: Vec::new() },
             brightness_threshold: 0.5,
+            logistic_model: None,
         }
     }
 

--- a/src/morphnet/training.rs
+++ b/src/morphnet/training.rs
@@ -1,5 +1,8 @@
 use super::*;
 use crate::TensorData;
+use linfa::prelude::*;
+use linfa_logistic::LogisticRegression;
+use ndarray::{Array1, Array2};
 
 pub fn train(net: &mut MorphNet, data: &[TensorData]) -> Result<()> {
     // Extremely small example "training" that adjusts the brightness threshold
@@ -16,5 +19,33 @@ pub fn train(net: &mut MorphNet, data: &[TensorData]) -> Result<()> {
         }
     }
     net.brightness_threshold = total / data.len() as f32;
+    Ok(())
+}
+
+/// Train a logistic regression classifier using labeled tensors.
+pub fn train_logistic(net: &mut MorphNet, data: &[(TensorData, usize)]) -> Result<()> {
+    if data.is_empty() {
+        return Ok(());
+    }
+
+    let n_samples = data.len();
+    let n_features = data[0].0.data.len();
+    let mut features = Array2::<f64>::zeros((n_samples, n_features));
+    let mut labels = Array1::<usize>::zeros(n_samples);
+
+    for (i, (tensor, label)) in data.iter().enumerate() {
+        let slice = tensor.data.as_slice().ok_or_else(|| MorphNetError::Training("invalid tensor".into()))?;
+        for (j, v) in slice.iter().enumerate() {
+            features[[i, j]] = *v as f64;
+        }
+        labels[i] = *label;
+    }
+
+    let dataset = linfa::Dataset::new(features, labels);
+    let model = LogisticRegression::default()
+        .max_iterations(100)
+        .fit(&dataset)
+        .map_err(|e| MorphNetError::Training(e.to_string()))?;
+    net.logistic_model = Some(model);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add `linfa-logistic` dependency
- store optional logistic regression model in `MorphNet`
- classify using logistic regression when available
- implement `train_logistic` for fitting a model
- re-export training helpers

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6841d0564e3c8330afa377e92529312f