### PR TITLE
Fix edition for crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "morphnet-gtl"
 version = "0.1.0"
-edition = "2025"
+edition = "2021"
 authors = ["Your Name <your.email@example.com>"]
 description = "Geometric Template Learning and Spatial Intelligence Framework"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- fix the `edition` in `Cargo.toml` back to 2021

## Testing
- `cargo test --quiet`
- `cargo publish --token $TOKEN` *(fails: A verified email address is required)*

------
https://chatgpt.com/codex/tasks/task_e_6841fdee0710833090102e9d1a2ff35f