### PR TITLE
Fix GitHub Pages deployment for VR demo

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          # Upload only the docs folder
+          path: 'docs'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MorphNet VR Demo</title>
+  <meta http-equiv="refresh" content="0; url=vrexample.html">
+</head>
+<body>
+  <p>Redirecting to <a href="vrexample.html">VR example</a>...</p>
+</body>
+</html>
+

--- a/docs/vrexample.html
+++ b/docs/vrexample.html
@@ -15,7 +15,6 @@
             overflow: hidden;
         }
 
-```
     #info {
         position: absolute;
         top: 10px;
@@ -51,7 +50,6 @@
         display: block;
     }
 </style>
-```
 
 </head>
 <body>
@@ -65,7 +63,6 @@
         <p>📊 No physics engine needed - cross-referencing tensor memory</p>
     </div>
 
-```
 <button id="vrButton">Enter VR</button>
 
 <script>
@@ -927,7 +924,6 @@
     // Start the experience
     animate();
 </script>
-```
 
 </body>
 </html>

--- a/examples/vrexample.html
+++ b/examples/vrexample.html
@@ -15,7 +15,6 @@
             overflow: hidden;
         }
 
-```
     #info {
         position: absolute;
         top: 10px;
@@ -51,7 +50,6 @@
         display: block;
     }
 </style>
-```
 
 </head>
 <body>
@@ -65,7 +63,6 @@
         <p>📊 No physics engine needed - cross-referencing tensor memory</p>
     </div>
 
-```
 <button id="vrButton">Enter VR</button>
 
 <script>
@@ -927,7 +924,6 @@
     // Start the experience
     animate();
 </script>
-```
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- clean up HTML in docs/examples
- add docs/index.html redirect for Pages
- deploy only `docs` folder on GitHub Pages

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6858a78625f48330b4a1beb06c2a19b2