### PR TITLE
Add MMX Swarm prototype

### DIFF
--- a/benches/mmx_benchmark.rs
+++ b/benches/mmx_benchmark.rs
@@ -1,239 +1,239 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
-use morphnet_gtl::mmx::{MMXBuilder, TensorData, MeshData, CompressionType};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use morphnet_gtl::mmx::chunks::MetaData;
-use ndarray::{Array3, ArrayD, IxDyn};
+use morphnet_gtl::mmx::{CompressionType, MMXBuilder, MeshData, TensorData};
 use nalgebra::Point3;
+use ndarray::{Array3, ArrayD, IxDyn};
 use tempfile::tempdir;
 
 fn bench_mmx_tensor_operations(c: &mut Criterion) {
-let mut group = c.benchmark_group(“mmx_tensor”);
+    let mut group = c.benchmark_group("mmx_tensor");
 
-```
-// Test different tensor sizes
-let sizes = [(64, 64, 3), (256, 256, 3), (512, 512, 3), (1024, 1024, 3)];
+    // Test different tensor sizes
+    let sizes = [(64, 64, 3), (256, 256, 3), (512, 512, 3), (1024, 1024, 3)];
 
-for (h, w, c_channels) in sizes.iter() {
-    let size = h * w * c_channels;
-    let tensor_data = create_test_tensor(*h, *w, *c_channels);
-    
-    group.bench_with_input(
-        BenchmarkId::new("write_tensor", size),
-        &tensor_data,
-        |b, tensor| {
+    for (h, w, c_channels) in sizes.iter() {
+        let size = h * w * c_channels;
+        let tensor_data = create_test_tensor(*h, *w, *c_channels);
+
+        group.bench_with_input(
+            BenchmarkId::new("write_tensor", size),
+            &tensor_data,
+            |b, tensor| {
+                b.iter(|| {
+                    let dir = tempdir().unwrap();
+                    let path = dir.path().join("test.mmx");
+                    let mut mmx_file = MMXBuilder::new("benchmark".to_string())
+                        .create(&path)
+                        .unwrap();
+
+                    black_box(
+                        mmx_file
+                            .write_tensor("/test_tensor", tensor.clone())
+                            .unwrap(),
+                    );
+                });
+            },
+        );
+
+        // Benchmark reading
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test_read.mmx");
+        let mut mmx_file = MMXBuilder::new("benchmark".to_string())
+            .create(&path)
+            .unwrap();
+        mmx_file
+            .write_tensor("/test_tensor", tensor_data.clone())
+            .unwrap();
+        drop(mmx_file);
+
+        group.bench_with_input(BenchmarkId::new("read_tensor", size), &path, |b, path| {
             b.iter(|| {
-                let dir = tempdir().unwrap();
-                let path = dir.path().join("test.mmx");
-                let mut mmx_file = MMXBuilder::new("benchmark".to_string())
-                    .create(&path).unwrap();
-                
-                black_box(mmx_file.write_tensor("/test_tensor", tensor.clone()).unwrap());
-            });
-        },
-    );
-    
-    // Benchmark reading
-    let dir = tempdir().unwrap();
-    let path = dir.path().join("test_read.mmx");
-    let mut mmx_file = MMXBuilder::new("benchmark".to_string())
-        .create(&path).unwrap();
-    mmx_file.write_tensor("/test_tensor", tensor_data.clone()).unwrap();
-    drop(mmx_file);
-    
-    group.bench_with_input(
-        BenchmarkId::new("read_tensor", size),
-        &path,
-        |b, path| {
-            b.iter(|| {
-                let mut mmx_file = morphnet_gtl::mmx::MMXFile::open(
-                    path, 
-                    morphnet_gtl::mmx::MMXMode::Read
-                ).unwrap();
+                let mut mmx_file =
+                    morphnet_gtl::mmx::MMXFile::open(path, morphnet_gtl::mmx::MMXMode::Read)
+                        .unwrap();
                 black_box(mmx_file.read_tensor("/test_tensor").unwrap());
             });
-        },
-    );
-}
+        });
+    }
 
-group.finish();
-```
-
+    group.finish();
 }
 
 fn bench_mmx_compression(c: &mut Criterion) {
-let mut group = c.benchmark_group(“mmx_compression”);
+    let mut group = c.benchmark_group("mmx_compression");
 
-```
-let tensor = create_test_tensor(256, 256, 3);
-let data = tensor.to_bytes();
+    let tensor = create_test_tensor(256, 256, 3);
+    let data = tensor.to_bytes();
 
-let compression_types = [
-    CompressionType::None,
-    CompressionType::Lz4,
-    CompressionType::Zlib,
-];
+    let compression_types = [
+        CompressionType::None,
+        CompressionType::Lz4,
+        CompressionType::Zlib,
+    ];
 
-for compression in compression_types.iter() {
-    group.bench_with_input(
-        BenchmarkId::new("compress", format!("{:?}", compression)),
-        &(data.clone(), *compression),
-        |b, (data, compression)| {
-            b.iter(|| {
-                black_box(morphnet_gtl::mmx::format::compress_data(data, *compression).unwrap());
-            });
-        },
-    );
-    
-    // Benchmark decompression
-    let compressed = morphnet_gtl::mmx::format::compress_data(&data, *compression).unwrap();
-    group.bench_with_input(
-        BenchmarkId::new("decompress", format!("{:?}", compression)),
-        &(compressed, *compression),
-        |b, (compressed, compression)| {
-            b.iter(|| {
-                black_box(morphnet_gtl::mmx::format::decompress_data(compressed, *compression).unwrap());
-            });
-        },
-    );
-}
+    for compression in compression_types.iter() {
+        group.bench_with_input(
+            BenchmarkId::new("compress", format!("{:?}", compression)),
+            &(data.clone(), *compression),
+            |b, (data, compression)| {
+                b.iter(|| {
+                    black_box(
+                        morphnet_gtl::mmx::format::compress_data(data, *compression).unwrap(),
+                    );
+                });
+            },
+        );
 
-group.finish();
-```
+        // Benchmark decompression
+        let compressed = morphnet_gtl::mmx::format::compress_data(&data, *compression).unwrap();
+        group.bench_with_input(
+            BenchmarkId::new("decompress", format!("{:?}", compression)),
+            &(compressed, *compression),
+            |b, (compressed, compression)| {
+                b.iter(|| {
+                    black_box(
+                        morphnet_gtl::mmx::format::decompress_data(compressed, *compression)
+                            .unwrap(),
+                    );
+                });
+            },
+        );
+    }
 
+    group.finish();
 }
 
 fn bench_mmx_mesh_operations(c: &mut Criterion) {
-let mut group = c.benchmark_group(“mmx_mesh”);
+    let mut group = c.benchmark_group("mmx_mesh");
 
-```
-let mesh_sizes = [100, 1000, 10000, 50000];
+    let mesh_sizes = [100, 1000, 10000, 50000];
 
-for vertex_count in mesh_sizes.iter() {
-    let mesh = create_test_mesh(*vertex_count);
-    
-    group.bench_with_input(
-        BenchmarkId::new("write_mesh", vertex_count),
-        &mesh,
-        |b, mesh| {
-            b.iter(|| {
-                let dir = tempdir().unwrap();
-                let path = dir.path().join("test.mmx");
-                let mut mmx_file = MMXBuilder::new("benchmark".to_string())
-                    .create(&path).unwrap();
-                
-                black_box(mmx_file.write_mesh("/test_mesh", mesh.clone()).unwrap());
-            });
-        },
-    );
-    
-    group.bench_with_input(
-        BenchmarkId::new("compute_normals", vertex_count),
-        &mesh,
-        |b, mesh| {
-            b.iter(|| {
-                let mut mesh_copy = mesh.clone();
-                black_box(mesh_copy.compute_normals());
-            });
-        },
-    );
-}
+    for vertex_count in mesh_sizes.iter() {
+        let mesh = create_test_mesh(*vertex_count);
 
-group.finish();
-```
+        group.bench_with_input(
+            BenchmarkId::new("write_mesh", vertex_count),
+            &mesh,
+            |b, mesh| {
+                b.iter(|| {
+                    let dir = tempdir().unwrap();
+                    let path = dir.path().join("test.mmx");
+                    let mut mmx_file = MMXBuilder::new("benchmark".to_string())
+                        .create(&path)
+                        .unwrap();
 
+                    black_box(mmx_file.write_mesh("/test_mesh", mesh.clone()).unwrap());
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("compute_normals", vertex_count),
+            &mesh,
+            |b, mesh| {
+                b.iter(|| {
+                    let mut mesh_copy = mesh.clone();
+                    black_box(mesh_copy.compute_normals());
+                });
+            },
+        );
+    }
+
+    group.finish();
 }
 
 fn bench_mmx_concurrent_access(c: &mut Criterion) {
-let mut group = c.benchmark_group(“mmx_concurrent”);
+    let mut group = c.benchmark_group("mmx_concurrent");
 
-```
-// Setup test file with multiple chunks
-let dir = tempdir().unwrap();
-let path = dir.path().join("concurrent_test.mmx");
-let mut mmx_file = MMXBuilder::new("benchmark".to_string())
-    .create(&path).unwrap();
+    // Setup test file with multiple chunks
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("concurrent_test.mmx");
+    let mut mmx_file = MMXBuilder::new("benchmark".to_string())
+        .create(&path)
+        .unwrap();
 
-// Write multiple tensors
-for i in 0..10 {
-    let tensor = create_test_tensor(128, 128, 3);
-    mmx_file.write_tensor(&format!("/tensor_{}", i), tensor).unwrap();
-}
-drop(mmx_file);
+    // Write multiple tensors
+    for i in 0..10 {
+        let tensor = create_test_tensor(128, 128, 3);
+        mmx_file
+            .write_tensor(&format!("/tensor_{}", i), tensor)
+            .unwrap();
+    }
+    drop(mmx_file);
 
-group.bench_function("concurrent_read", |b| {
-    b.iter(|| {
-        use std::sync::Arc;
-        use std::thread;
-        
-        let path = Arc::new(path.clone());
-        let handles: Vec<_> = (0..4).map(|thread_id| {
-            let path = Arc::clone(&path);
-            thread::spawn(move || {
-                let mut mmx_file = morphnet_gtl::mmx::MMXFile::open(
-                    &*path, 
-                    morphnet_gtl::mmx::MMXMode::Read
-                ).unwrap();
-                
-                for i in 0..3 {
-                    let tensor_name = format!("/tensor_{}", (thread_id * 2 + i) % 10);
-                    black_box(mmx_file.read_tensor(&tensor_name).unwrap());
-                }
-            })
-        }).collect();
-        
-        for handle in handles {
-            handle.join().unwrap();
-        }
+    group.bench_function("concurrent_read", |b| {
+        b.iter(|| {
+            use std::sync::Arc;
+            use std::thread;
+
+            let path = Arc::new(path.clone());
+            let handles: Vec<_> = (0..4)
+                .map(|thread_id| {
+                    let path = Arc::clone(&path);
+                    thread::spawn(move || {
+                        let mut mmx_file = morphnet_gtl::mmx::MMXFile::open(
+                            &*path,
+                            morphnet_gtl::mmx::MMXMode::Read,
+                        )
+                        .unwrap();
+
+                        for i in 0..3 {
+                            let tensor_name = format!("/tensor_{}", (thread_id * 2 + i) % 10);
+                            black_box(mmx_file.read_tensor(&tensor_name).unwrap());
+                        }
+                    })
+                })
+                .collect();
+
+            for handle in handles {
+                handle.join().unwrap();
+            }
+        });
     });
-});
 
-group.finish();
-```
-
+    group.finish();
 }
 
 // Helper functions
 fn create_test_tensor(height: usize, width: usize, channels: usize) -> TensorData {
-let data = ArrayD::zeros(IxDyn(&[height, width, channels]));
-TensorData::new(data)
+    let data = ArrayD::zeros(IxDyn(&[height, width, channels]));
+    TensorData::new(data)
 }
 
 fn create_test_mesh(vertex_count: usize) -> MeshData {
-let mut mesh = MeshData::new();
+    let mut mesh = MeshData::new();
 
-```
-// Create vertices in a grid pattern
-let grid_size = (vertex_count as f32).sqrt() as usize;
-for i in 0..grid_size {
-    for j in 0..grid_size {
+    // Create vertices in a grid pattern
+    let grid_size = (vertex_count as f32).sqrt() as usize;
+    for i in 0..grid_size {
+        for j in 0..grid_size {
+            if mesh.vertices.len() >= vertex_count {
+                break;
+            }
+            mesh.add_vertex(Point3::new(i as f32, j as f32, 0.0));
+        }
         if mesh.vertices.len() >= vertex_count {
             break;
         }
-        mesh.add_vertex(Point3::new(i as f32, j as f32, 0.0));
     }
-    if mesh.vertices.len() >= vertex_count {
-        break;
+
+    // Create triangular faces
+    let faces_to_create = std::cmp::min(vertex_count / 3, (grid_size - 1) * (grid_size - 1) * 2);
+    for i in 0..faces_to_create {
+        let v0 = (i * 3) % mesh.vertices.len();
+        let v1 = (i * 3 + 1) % mesh.vertices.len();
+        let v2 = (i * 3 + 2) % mesh.vertices.len();
+        mesh.add_face([v0 as u32, v1 as u32, v2 as u32]);
     }
-}
 
-// Create triangular faces
-let faces_to_create = std::cmp::min(vertex_count / 3, (grid_size - 1) * (grid_size - 1) * 2);
-for i in 0..faces_to_create {
-    let v0 = (i * 3) % mesh.vertices.len();
-    let v1 = (i * 3 + 1) % mesh.vertices.len();
-    let v2 = (i * 3 + 2) % mesh.vertices.len();
-    mesh.add_face([v0 as u32, v1 as u32, v2 as u32]);
-}
-
-mesh
-```
-
+    mesh
 }
 
 criterion_group!(
-benches,
-bench_mmx_tensor_operations,
-bench_mmx_compression,
-bench_mmx_mesh_operations,
-bench_mmx_concurrent_access
+    benches,
+    bench_mmx_tensor_operations,
+    bench_mmx_compression,
+    bench_mmx_mesh_operations,
+    bench_mmx_concurrent_access
 );
 criterion_main!(benches);

--- a/mmx_swarm/README.md
+++ b/mmx_swarm/README.md
@@ -1,0 +1,22 @@
+# MMX Swarm Prototype
+
+This directory contains an early prototype for a Swarm-style intelligence system.
+
+Currently implemented components:
+
+- **ImmediateMemory** – in-memory circular buffer of recent messages.
+- **SessionStore** – SQLite-backed log with keyword and sentiment tagging.
+- **REST API** – simple Flask server exposing session retrieval and tagging.
+- **Demo** – script that logs 1,000 messages and demonstrates keyword search.
+
+Run the demo:
+
+```bash
+python -m mmx_swarm.demo
+```
+
+Run the API server:
+
+```bash
+python -m mmx_swarm.app
+```

--- a/mmx_swarm/app.py
+++ b/mmx_swarm/app.py
@@ -1,0 +1,27 @@
+from flask import Flask, jsonify, request
+from .memory_core import SessionStore
+
+
+def create_app(db_path: str = "memory_lane.db") -> Flask:
+    app = Flask(__name__)
+    store = SessionStore(db_path=db_path, keywords=["AI"])
+
+    @app.route("/memory/session")
+    def memory_session():
+        entries = store.get_recent(100)
+        return jsonify(entries)
+
+    @app.route("/memory/tag", methods=["POST"])
+    def memory_tag():
+        data = request.get_json(force=True)
+        entry_id = int(data.get("id"))
+        tag = data.get("tag")
+        store.add_tag(entry_id, tag)
+        return jsonify({"status": "ok"})
+
+    return app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    app.run(debug=True)

--- a/mmx_swarm/demo.py
+++ b/mmx_swarm/demo.py
@@ -1,0 +1,18 @@
+from .memory_core import ImmediateMemory, SessionStore
+
+
+def main():
+    mem = ImmediateMemory()
+    store = SessionStore(db_path=":memory:", keywords=["AI"])
+
+    for i in range(1000):
+        text = f"AI message {i}" if i % 100 == 0 else f"message {i}"
+        store.insert("user", text)
+        mem.append("user", text)
+
+    matches = store.search("AI")
+    print(f"Found {len(matches)} AI messages")
+
+
+if __name__ == "__main__":
+    main()

--- a/mmx_swarm/memory_core.py
+++ b/mmx_swarm/memory_core.py
@@ -1,0 +1,102 @@
+import sqlite3
+import json
+from collections import deque
+from datetime import datetime
+from typing import List, Optional
+
+try:
+    from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+    _analyzer = SentimentIntensityAnalyzer()
+except Exception:
+    _analyzer = None
+
+class ImmediateMemory:
+    """Simple in-memory circular buffer of recent messages."""
+    def __init__(self, buffer_size: int = 500):
+        self.buffer_size = buffer_size
+        self._buffer = deque(maxlen=buffer_size)
+
+    def append(self, speaker: str, text: str) -> None:
+        self._buffer.append({"speaker": speaker, "text": text})
+
+    def get_recent(self, k: int) -> List[dict]:
+        return list(self._buffer)[-k:]
+
+class SessionStore:
+    """SQLite-backed session log with basic tagging."""
+    def __init__(self, db_path: str = "memory_lane.db", keywords: Optional[List[str]] = None, vader_threshold: float = 0.5):
+        self.conn = sqlite3.connect(db_path)
+        self.keywords = keywords or []
+        self.vader_threshold = vader_threshold
+        self._init_table()
+
+    def _init_table(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS session (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                speaker TEXT,
+                text TEXT,
+                tags TEXT
+            )
+            """
+        )
+        self.conn.commit()
+
+    def insert(self, speaker: str, text: str) -> int:
+        tags = []
+        for kw in self.keywords:
+            if kw.lower() in text.lower():
+                tags.append(kw)
+        if _analyzer:
+            score = _analyzer.polarity_scores(text)["compound"]
+            if score >= self.vader_threshold:
+                tags.append("positive")
+            elif score <= -self.vader_threshold:
+                tags.append("negative")
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO session(timestamp, speaker, text, tags) VALUES (?, ?, ?, ?)",
+            (datetime.utcnow().isoformat(), speaker, text, json.dumps(tags)),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
+    def get_recent(self, limit: int = 100) -> List[dict]:
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT id, timestamp, speaker, text, tags FROM session ORDER BY id DESC LIMIT ?",
+            (limit,),
+        )
+        rows = cur.fetchall()
+        return [
+            {"id": r[0], "timestamp": r[1], "speaker": r[2], "text": r[3], "tags": json.loads(r[4])}
+            for r in rows
+        ]
+
+    def add_tag(self, entry_id: int, tag: str) -> None:
+        cur = self.conn.cursor()
+        cur.execute("SELECT tags FROM session WHERE id = ?", (entry_id,))
+        row = cur.fetchone()
+        if not row:
+            return
+        tags = json.loads(row[0])
+        if tag not in tags:
+            tags.append(tag)
+        cur.execute("UPDATE session SET tags = ? WHERE id = ?", (json.dumps(tags), entry_id))
+        self.conn.commit()
+
+    def search(self, query: str) -> List[dict]:
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT id, timestamp, speaker, text, tags FROM session WHERE text LIKE ?",
+            (f"%{query}%",),
+        )
+        rows = cur.fetchall()
+        return [
+            {"id": r[0], "timestamp": r[1], "speaker": r[2], "text": r[3], "tags": json.loads(r[4])}
+            for r in rows
+        ]
+


### PR DESCRIPTION
## Summary
- add `mmx_swarm` prototype with memory system and REST API
- fix malformed quotes in `mmx_benchmark.rs`

## Testing
- `cargo fmt --check`
- `cargo clippy -- -D warnings` *(fails: new_without_default, etc.)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687267a474648330a7d70ff713347941