### PR TITLE
feat: Python bindings wrapper + ViPE post-stage + dual license + wheels CI

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main, feature/** ]
   pull_request:
 
+permissions:
+  contents: read
 jobs:
   build:
     strategy:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,32 @@
+name: Build Python wheels
+
+on:
+  push:
+    branches: [ main, feature/** ]
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        py: ["3.9", "3.10", "3.11", "3.12"]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: bindings/python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.py }}
+      - name: Install maturin
+        run: pip install maturin
+      - name: Build wheels
+        run: maturin build --release -i ${{ matrix.py }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-py${{ matrix.py }}
+          path: bindings/python/target/wheels/*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+/target
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.whl
+/.venv
+/.maturin
+/dist
+.DS_Store

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2025 Your Name
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Your Name
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+MorphNet includes components licensed under the MIT OR Apache-2.0 license.
+Copyright (c) 2025 Your Name

--- a/README.md
+++ b/README.md
@@ -370,3 +370,14 @@ The theoretical connection between visual understanding and AGI appears increasi
 
 The path forward likely demands hybrid architectures combining the strengths of different learning paradigms, better theoretical frameworks bridging cognitive science and AI research, and evaluation methodologies that meaningfully assess progress toward human-level visual intelligence. Success in this endeavor will not only advance computer vision but may prove essential for the broader goal of developing artificial general intelligence systems capable of flexible reasoning and understanding across diverse domains and contexts.
 
+
+## Python bindings & ViPE post-stage
+
+Dev install:
+```bash
+pip install maturin
+cd bindings/python && maturin develop --release
+
+Run after vipe infer ...:
+
+python integrations/vipe_post/morphnet.py --vipe_results ./vipe_results --out ./vipe_results/morphnet

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "morphnet_py"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[lib]
+name = "morphnet"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.22", features = ["extension-module"] }
+
+# Optional: if/when you want to call into the core crate, uncomment and adjust:
+# morphnet = { path = "../..", version = "*" }

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,0 +1,12 @@
+# morphnet (Python wrapper)
+
+Build (dev):
+```bash
+pip install maturin
+cd bindings/python
+maturin develop --release
+
+API:
+
+from morphnet import guided_patch
+ellipse, spline, quality = guided_patch("path/to/depth.npy", None, 2, 4.0, 0.1, 0.0)

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["maturin>=1.5,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "morphnet"
+version = "0.1.0"
+description = "MorphNet guided patcher (ViPE post-stage ready)"
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [{name="Your Name"}]
+license = { text = "MIT OR Apache-2.0" }
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Rust",
+]
+
+[tool.maturin]
+# Build from this sub-crate
+bindings = "pyo3"
+module-name = "morphnet"

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,0 +1,25 @@
+use pyo3::prelude::*;
+
+/// Minimal GUIDED mode stub for now (compiles without touching core crate).
+/// Returns: (ellipse_params [cx, cy, a, b, theta], spline_points [(x,y)...], quality_score)
+#[pyfunction]
+fn guided_patch(
+    depth_path: &str,
+    flow_path: Option<&str>,
+    max_iters: usize,
+    aspect_ratio_max: f32,
+    curvature_lambda: f32,
+    area_prior: f32,
+) -> PyResult<(Vec<f32>, Vec<(f32, f32)>, f32)> {
+    // TODO: replace with real call into core crate once API is ready.
+    let ellipse_params = vec![320.0, 180.0, 64.0, 48.0, 0.0];
+    let spline_points = vec![(300.0, 180.0), (340.0, 180.0)];
+    let quality_score = 0.0;
+    Ok((ellipse_params, spline_points, quality_score))
+}
+
+#[pymodule]
+fn morphnet(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(guided_patch, m)?)?;
+    Ok(())
+}

--- a/integrations/vipe_post/morphnet.py
+++ b/integrations/vipe_post/morphnet.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import argparse, json, glob
+from pathlib import Path
+
+try:
+    from morphnet import guided_patch
+except Exception as e:
+    raise SystemExit(f"Import error: install morphnet wheel first. {e}")
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--vipe_results", required=True, help="Path to vipe_results/")
+    ap.add_argument("--out", required=True, help="Output directory for morphnet artifacts")
+    ap.add_argument("--max_iters", type=int, default=2)
+    ap.add_argument("--aspect_ratio_max", type=float, default=4.0)
+    ap.add_argument("--curvature_lambda", type=float, default=0.1)
+    ap.add_argument("--area_prior", type=float, default=0.0)
+    args = ap.parse_args()
+
+    vipe = Path(args.vipe_results)
+    out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+
+    depth_files = sorted(glob.glob(str(vipe / "depth" / "*.npy")))
+    flow_files = sorted(glob.glob(str(vipe / "flow" / "*.npy")))
+
+    for i, dpth in enumerate(depth_files):
+        flow = flow_files[i] if i < len(flow_files) else None
+        ellipse, spline, quality = guided_patch(
+            dpth, flow, args.max_iters,
+            args.aspect_ratio_max, args.curvature_lambda, args.area_prior
+        )
+        payload = {
+            "frame_index": i,
+            "ellipse_params": {"cx": ellipse[0], "cy": ellipse[1], "a": ellipse[2], "b": ellipse[3], "theta": ellipse[4]},
+            "spline": [{"x": p[0], "y": p[1]} for p in spline],
+            "quality": quality,
+        }
+        (out / f"morphnet_{i:06d}.json").write_text(json.dumps(payload))
+
+    print(f"[morphnet] wrote {len(depth_files)} json files to {out}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add MIT and Apache-2.0 license texts plus NOTICE to enable dual licensing
- introduce a Python bindings crate with a stubbed `guided_patch` API and document dev usage
- provide a ViPE post-stage integration script and CI workflow to build wheels across platforms
- append README notes for developing and running the new Python tooling

## Testing
- `cargo fmt --check` *(fails: repository contains pre-existing formatting differences in core sources)*
- `cargo clippy -- -D warnings` *(fails: existing clippy warnings in core crate unrelated to new files)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68fd14a383b4833091d627ff4fb55c1a